### PR TITLE
Added Params sending to gps

### DIFF
--- a/lib/angular/gps/gps-service.js
+++ b/lib/angular/gps/gps-service.js
@@ -12,13 +12,13 @@ angular.module('wfm.gps').service('gps', ['mediator', GpsService]);
 function GpsService(mediator) {
 
   //Subscribing for the `wfm:gps:location:update` topic to get the current location.
-  mediator.subscribe('wfm:gps:location:update', function() {
+  mediator.subscribe('wfm:gps:location:update', function(params) {
 
     //The current location is obtained from the navigator (https://developer.mozilla.org/en-US/docs/Web/API/Geolocation/getCurrentPosition)
     if (navigator && navigator.geolocation) {
       navigator.geolocation.getCurrentPosition(function(location) {
         //The current location has been obtained. Publish the topic done state with the current location.
-        mediator.publish('done:wfm:gps:location:update', location);
+        mediator.publish('done:wfm:gps:location:update', location, params);
       }, function(err) {
         //There was an error getting the current position.
         mediator.publish('error:wfm:gps:location:update', new Error(err.message ? err.message : err));


### PR DESCRIPTION
The reason of this PR is that sometimes you can track several things (userLoc,workorder) at the same time with different Intervals, thats why it's very helpfull to send parameters with the publish method to get  the required info on "done:" event, because it can be a location update for the user, for the workorderId=2 or workorderId="3".